### PR TITLE
Fix subscriptions by replacing deprecated sources API with paymentIntent

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import koaBody from 'koa-body';
 import config from "./config.js"
 import alphanumeric from "alphanumeric-id";
 import {postDonateCard} from "./routes/donate_card.js";
+import {postCreateSubscription} from "./routes/create_subscription.js";
 import {postStripeWebhook} from "./routes/stripe_webhook.js";
 import {postCreateIntent} from "./routes/create_intent.js";
 import {postFinishIntent} from "./routes/finish_intent.js";
@@ -73,6 +74,7 @@ appRouter.get("/config", async (ctx) => {
     publicKey: config["stripe"]["publicKey"]
   }
 });
+appRouter.post("/subscription", ...postCreateSubscription)
 appRouter.post("/donate/sepa", ...postDonateSepa)
 appRouter.post("/donate/card", ...postDonateCard)
 appRouter.post("/payment-intent", ...postCreateIntent)

--- a/src/routes/create_subscription.js
+++ b/src/routes/create_subscription.js
@@ -1,0 +1,40 @@
+import { stripe } from "../stripe_helper.js";
+import { getJoiMiddleware } from "../shared.js";
+import Joi from "joi";
+import { getOrCreateCustomer, getSubscriptionPrice } from "./donate_shared.js";
+
+export const postCreateSubscription = [
+  getJoiMiddleware(Joi.object({
+    name: Joi.string().required().trim().min(3),
+    email: Joi.string().trim().required().email(),
+    amount: Joi.number().min(1).max(1000).precision(2).required(),
+  })),
+
+  async (ctx) => {
+    const { amount, email, name } = ctx.request.body;
+    const customer = await getOrCreateCustomer(ctx, email, name);
+
+    ctx.log(`Creating subscription (Email: ${email}, Amount (EUR): ${amount})`)
+
+    const price = await getSubscriptionPrice(ctx, amount);
+    const subscription = await stripe.subscriptions.create({
+      customer: customer.id,
+      items: [
+        { price: price.id }
+      ],
+      payment_behavior: 'default_incomplete',
+      payment_settings: { save_default_payment_method: 'on_subscription' },
+    });
+    ctx.log(`Created a monthly subscription ${subscription.id}`)
+
+    const invoice = await stripe.invoices.retrieve(subscription.latest_invoice);
+    const paymentIntent = await stripe.paymentIntents.retrieve(invoice.payment_intent);
+
+    ctx.log(`Payment intent to be paid to activate subscription: ${paymentIntent.id}`)
+
+    ctx.body = {
+      subscriptionId: subscription.id,
+      secret: paymentIntent.client_secret,
+    }
+  }
+]

--- a/src/routes/finish_intent.js
+++ b/src/routes/finish_intent.js
@@ -36,10 +36,13 @@ export const postFinishIntent = [
       return ctx.withError(404, "Unable to retrieve payment method");
     }
 
+    // Figure out donation type - if it has an invoice associated, it is a subscription
+    const donationType = paymentIntent.invoice ? DonationType.Monthly : DonationType.OneTime;
+
     ctx.log(`Finishing payment intent ${paymentIntent.id}, amount: ${paymentIntent.amount}`)
 
     await handleMauticDonation(ctx, customer, {
-      type: DonationType.OneTime,
+      type: donationType,
       amountCents: paymentIntent.amount,
       paymentMethod: paymentMethod.type,
       charge

--- a/src/routes/finish_intent.js
+++ b/src/routes/finish_intent.js
@@ -37,7 +37,7 @@ export const postFinishIntent = [
     }
 
     // Figure out donation type - if it has an invoice associated, it is a subscription
-    const donationType = paymentIntent.invoice ? DonationType.Monthly : DonationType.OneTime;
+    const donationType = paymentIntent.invoice != null ? DonationType.Monthly : DonationType.OneTime;
 
     ctx.log(`Finishing payment intent ${paymentIntent.id}, amount: ${paymentIntent.amount}`)
 


### PR DESCRIPTION
For context: for monthly payments we used the now deprecated sources API in combination with subscriptions. One-time payments already were using the paymentIntents API.

Now, paymentIntents replace sources for monthly payments as well. This means we can simplify a lot of the code, since we now use paymentIntents for everything.

In case of monthly payments, we now create a subscription first without payment via the new POST /subscription endpoint. Stripe will create the first invoice for us automatically, and we can return the corresponding paymentIntent client_secret just like we do on the POST /payment-intent endpoint.

This means we can treat both endpoints the same on the client-side and stripe will handle the authorization process for e.g. 3DS enabled credit cards on its own. Afterwards we POST /payment-intent/finish in both scenarios.

---

Other notes:
 - This requires changes on the client side as well
 - The `POST /donate/sepa` and `POST /donate/card` routes are then effectively unused and might be candidates to be removed
 - Only regression I have not figured out yet is the mandate url, that was retrieved and displayed to the user when donating monthly via SEPA. Not yet sure how to retrieve it without the Sources API